### PR TITLE
Update Schema and ActiveAdmin to use has_many :through association

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -1,12 +1,12 @@
 ActiveAdmin.register Product do
 
-permit_params :title, :categories_id, :price, :description, :cover
+    permit_params :title, :price, :description, :cover, :category_ids => []
 
   	form html: { multipart: true } do |f|
 
 	  	f.inputs "Product | New" do
 	    	f.input :title
-	    	f.input :categories_id, as: :select, :collection => Category.all.collect {|category| [category.title, category.id] }
+	    	f.input :categories, as: :select, :collection => Category.all.collect {|category| [category.title, category.id] }
 	    	f.input :price
 	    	f.input :description
 	    	f.input :cover, as: :file

--- a/db/migrate/20180318172136_remove_categories_id_from_products_2.rb
+++ b/db/migrate/20180318172136_remove_categories_id_from_products_2.rb
@@ -1,0 +1,9 @@
+class RemoveCategoriesIdFromProducts2 < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :products, :categories_id
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180317083708) do
+ActiveRecord::Schema.define(version: 20180318172136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,8 +100,6 @@ ActiveRecord::Schema.define(version: 20180317083708) do
     t.datetime "updated_at", null: false
     t.string "cover"
     t.string "cover_filename"
-    t.bigint "categories_id"
-    t.index ["categories_id"], name: "index_products_on_categories_id"
     t.index ["title"], name: "index_products_on_title", unique: true
   end
 
@@ -129,5 +127,4 @@ ActiveRecord::Schema.define(version: 20180317083708) do
   add_foreign_key "product_categories", "categories", name: "fk_product_categories_to_categories"
   add_foreign_key "product_categories", "products", name: "fk_product_categories_to_products"
   add_foreign_key "product_variants", "products", name: "fk_product_variants_to_product"
-  add_foreign_key "products", "categories", column: "categories_id"
 end


### PR DESCRIPTION
Since we are using a `has_many :through` association for products -> categories we need to tell ActiveAdmin to use end associtation. For this to work we need to also allow ActiveAdmin to receive the `category_ids` paramter. Notice how this is the singlar version of the resource appended by `_ids`.